### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ no semicolons and no code blocks because of this fact.
 
 ### Currying and prefix calling
 
-In Tao, `arg:f` is shorthand for `f(arg)` (function application). Additionally, this prefix syntax can be chained,
+In Tao, `arg->f` is shorthand for `f(arg)` (function application). Additionally, this prefix syntax can be chained,
 resulting in very natural, first-class pipeline syntax.
 
 ```py


### PR DESCRIPTION
Just a friendly drive-by PR, it looks like `->` is used for function chaining instead of `:` in the rest of the code-examples.