### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: monthly
+  commit-message:
+    prefix: "Cargo"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly
+  commit-message:
+    prefix: "Actions"


### PR DESCRIPTION
This should not be merged before the CI PR (#50) is decided on.

Because if this is merged, it might open up a lot of PRs quickly, and they are much easier to handle if (for example) bors is set up (see #50).